### PR TITLE
Update regex

### DIFF
--- a/xibosignage-youtube.xml
+++ b/xibosignage-youtube.xml
@@ -64,7 +64,7 @@
     var readyCalled = false;
 
     // Extracts the video ID using regex directly in JS
-    var pattern = /(?:v=|embed\/|youtu\.be\/|\/live\/)([^?&/]+)/;
+    var pattern = /^(?:https?:\/\/)?(?:www\.)?(?:(?:youtu\.be\/(?:v\/)?|y2u\.be\/(?:v\/)?)|youtube\.com\/(?:shorts\/|v\/|vi\/|e\/|embed\/|live\/|watch\?(?:v|vi)=|\?(?:v|vi)=))([^?&\/]+)/i;
     var match = url.match(pattern);
     var videoId = (match && match[1]) ? match[1] : '';
 


### PR DESCRIPTION
Updated regex to match the ID (*) on common YouTube URL patterns:

youtu.be/*
y2u.be/*
youtube.com/v/*
youtube.com/vi/*
youtube.com/watch?v=*
youtube.com/watch?vi=*
youtube.com/?vi=*
youtube.com/?v=*
youtube.com/e/*
youtube.com/embed/*
youtube.com/live/*
youtube.com/shorts/*
https://youtube.com/watch?v=*
http://www.youtube.com/watch?v=*&feature=featured
www.youtube.com/v/*